### PR TITLE
Add daily check GitHub Action workflow

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -1,0 +1,32 @@
+name: Daily IIIS Seminar Check
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Runs at 8:00 AM UTC daily
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  check-and-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Run IIIS Watcher
+        env:
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          EMAIL_USER: ${{ secrets.EMAIL_USER }}
+          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+          RECIPIENT_EMAIL: ${{ secrets.RECIPIENT_EMAIL }}
+        run: |
+          python -m iiis_watcher --check


### PR DESCRIPTION
This PR adds a GitHub Action workflow that:
- Runs daily at 8:00 AM UTC
- Checks for IIIS seminar updates
- Sends email notifications

Note: The following secrets need to be set in GitHub before merging:
- SMTP_SERVER
- SMTP_PORT
- EMAIL_USER
- EMAIL_PASSWORD
- RECIPIENT_EMAIL